### PR TITLE
rcsbsearch version in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ docker pull adaptyvbio/proteinflow
 ### Troubleshooting
 - If you are using python 3.10 and encountering installation problems, try running `python -m pip install prody==2.4.0` before installing `proteinflow`.
 - If you are planning to generate new datasets and installed `proteinflow` with `pip`, you will need to additionally install [`mmseqs`](https://github.com/soedinglab/MMseqs2).
-- Generating new datasets also depends on the `rcsbsearch` package and the latest release [v0.2.3](https://github.com/sbliven/rcsbsearch/releases/tag/v0.2.3) is currently not working correctly. The recommended fix is installing the version from [this pull request](https://github.com/sbliven/rcsbsearch/pull/6).
-```bash
-python -m pip install "rcsbsearch @ git+https://github.com/sbliven/rcsbsearch@dbdfe3880cc88b0ce57163987db613d579400c8e"
-```
 - The docker image can be accessed in interactive mode with this command.
 ```bash
 docker run -it -v /path/to/data:/media adaptyvbio/proteinflow bash

--- a/proteinflow/utils/common_utils.py
+++ b/proteinflow/utils/common_utils.py
@@ -62,19 +62,6 @@ def _clean(pdb_id, tmp_folder):
             )
 
 
-def _raise_rcsbsearch(e):
-    """
-    Raise a RuntimeError if the error is due to rcsbsearch
-    """
-
-    if "404 Client Error" in str(e):
-        raise RuntimeError(
-            'Quering rcsbsearch is failing. Please install a version of rcsbsearch where this error is solved:\npython -m pip install "rcsbsearch @ git+https://github.com/sbliven/rcsbsearch@dbdfe3880cc88b0ce57163987db613d579400c8e"'
-        )
-    else:
-        raise e
-
-
 def _make_sabdab_html(method, resolution_thr):
     """
     Make a URL for SAbDab search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "aiobotocore==2.4.2",
     "awscli==1.25.60",
     "bs4>=0.0.1",
-    "rcsbsearch",
+    "rcsbsearch @ git+https://github.com/sbliven/rcsbsearch@dbdfe3880cc88b0ce57163987db613d579400c8e", # https://github.com/sbliven/rcsbsearch/pull/6
 ]
 keywords = ["bioinformatics", "dataset", "protein", "PDB", "deep learning"]
 


### PR DESCRIPTION
Since the [RCSB](https://github.com/sbliven/rcsbsearch) development has been stalled, don't think there is a reason to add the latest version in the dependency. Have removed the exception and also the documentation for a manual install otherwise.