### PR TITLE
change CDR ranges

### DIFF
--- a/proteinflow/constants.py
+++ b/proteinflow/constants.py
@@ -162,8 +162,8 @@ SIDECHAIN_ORDER = {
 
 BACKBONE_ORDER = ["N", "C", "CA", "O"]
 CDR_ENDS = {
-    "L": {"L1": (26, 32), "L2": (50, 52), "L3": (91, 96)},
-    "H": {"H1": (26, 32), "H2": (52, 56), "H3": (96, 101)},
+    "L": {"L1": (24, 34), "L2": (50, 56), "L3": (89, 97)},
+    "H": {"H1": (31, 35), "H2": (50, 65), "H3": (95, 102)},
 }
 CDR_VALUES = {"L": defaultdict(lambda: "-"), "H": defaultdict(lambda: "-")}
 for chain_type in ["L", "H"]:


### PR DESCRIPTION
change the CDR range definitions from consensus to the ones utilized by the tool used in SAbDab _(Abhinandan, K. R., and Andrew CR Martin. "Analysis and improvements to Kabat and structurally correct numbering of antibody variable domains." Molecular immunology 45.14 (2008): 3832-3839)._