### PR TITLE
pin version of blosum package in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "awscli==1.25.60",
     "bs4>=0.0.1",
     "rcsbsearch",
-    "blosum",
+    "blosum>=2.0",
     "pre-commit",
 ]
 keywords = ["bioinformatics", "dataset", "protein", "PDB", "deep learning"]


### PR DESCRIPTION
## What
This PR sets a minimum version requirement of the `blosum` package in the `pyproject.toml`.

## Why
This is needed as the syntax changed from version 1.x to 2.x.
In this package the 2.x syntax is used.


 